### PR TITLE
New regex for number

### DIFF
--- a/components/prism-javascript.js
+++ b/components/prism-javascript.js
@@ -18,7 +18,7 @@ Prism.languages.javascript = Prism.languages.extend('clike', {
 	],
 	// Allow for all non-ASCII characters (See http://stackoverflow.com/a/2008444)
 	'function': /#?(?!\s)[_$a-zA-Z\xA0-\uFFFF](?:(?!\s)[$\w\xA0-\uFFFF])*(?=\s*(?:\.\s*(?:apply|bind|call)\s*)?\()/,
-	'number': /\b(?:(?:0[xX](?:[\dA-Fa-f](?:_[\dA-Fa-f])?)+|0[bB](?:[01](?:_[01])?)+|0[oO](?:[0-7](?:_[0-7])?)+)n?|(?:\d(?:_\d)?)+n|NaN|Infinity)\b|(?:\b(?:\d(?:_\d)?)+\.?(?:\d(?:_\d)?)*|\B\.(?:\d(?:_\d)?)+)(?:[Ee][+-]?(?:\d(?:_\d)?)+)?/,
+	'number': /\b(?:(?:0[xX](?:[\dA-Fa-f](?:_[\dA-Fa-f])*)+|0[bB](?:[01](?:_[01])*)+|0[oO](?:[0-7](?:_[0-7])*)+)n?|(?:\d(?:_\d)*)+n|NaN|Infinity)\b|(?:\b(?:\d(?:_\d)*)+\.?(?:\d(?:_\d)*)*|\B\.(?:\d(?:_\d)*)+)(?:[Ee][+-]?(?:\d(?:_\d)*)+)?/,
 	'operator': /--|\+\+|\*\*=?|=>|&&=?|\|\|=?|[!=]==|<<=?|>>>?=?|[-+*/%&|^!=<>]=?|\.{3}|\?\?=?|\?\.?|[~:]/
 });
 


### PR DESCRIPTION
The old regex for detecting number doesn't work in following edge cases:
0xf_f_f_f_ffn,
0xf_f_f_f_f,
0b1_1_1_1,
0b0_0_1_0_1_0_1n,
0o1_1_3_2,
0o1_1_3_2n,
2.2_4_54e64_33,
2.2_4_54e+64_33,
2.2_4_54e-64_33,
3_4_5,
3_4_5.5_5_6

The new one also detects these kind of numbers. (I know these are rare and not encouraged, but I think it should be also supported because they are also valid numbers). 